### PR TITLE
Update delegate method naming

### DIFF
--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -10,9 +10,9 @@ import UIKit
 import AVFoundation
 
 public protocol QRScannerViewDelegate: AnyObject {
-    func failure(_ error: QRScannerError)
-    func success(_ code: String)
-    func didChangeTorchActive(isOn: Bool)
+    func qrScannerView(_ qrScannerView: QRScannerView, didFailure error: QRScannerError)
+    func qrScannerView(_ qrScannerView: QRScannerView, didSuccess code: String)
+    func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool)
 }
 
 @IBDesignable
@@ -273,15 +273,15 @@ public class QRScannerView: UIView {
     }
 
     private func failure(_ error: QRScannerError) {
-        delegate?.failure(error)
+        delegate?.qrScannerView(self, didFailure: error)
     }
 
     private func success(_ code: String) {
-        delegate?.success(code)
+        delegate?.qrScannerView(self, didSuccess: code)
     }
 
     private func didChangeTorchActive(isOn: Bool) {
-        delegate?.didChangeTorchActive(isOn: isOn)
+        delegate?.qrScannerView(self, didChangeTorchActive: isOn)
     }
 }
 

--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -9,12 +9,20 @@
 import UIKit
 import AVFoundation
 
+// MARK: - QRScannerViewDelegate
 public protocol QRScannerViewDelegate: AnyObject {
+    // Required
     func qrScannerView(_ qrScannerView: QRScannerView, didFailure error: QRScannerError)
     func qrScannerView(_ qrScannerView: QRScannerView, didSuccess code: String)
+    // Optional
     func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool)
 }
 
+public extension QRScannerViewDelegate {
+    func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool) {}
+}
+
+// MARK: - QRScannerView
 @IBDesignable
 public class QRScannerView: UIView {
 

--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -18,7 +18,7 @@ public protocol QRScannerViewDelegate: AnyObject {
     func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool)
 }
 
-public extension QRScannerViewDelegate {
+public extension QRScannerViewDelegate where Self: AnyObject {
     func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool) {}
 }
 

--- a/QRScannerSample/QRScannerSample/ViewController.swift
+++ b/QRScannerSample/QRScannerSample/ViewController.swift
@@ -41,11 +41,11 @@ final class ViewController: UIViewController {
 
 // MARK: - QRScannerViewDelegate
 extension ViewController: QRScannerViewDelegate {
-    func failure(_ error: QRScannerError) {
+    func qrScannerView(_ qrScannerView: QRScannerView, didFailure error: QRScannerError) {
         print(error.localizedDescription)
     }
 
-    func success(_ code: String) {
+    func qrScannerView(_ qrScannerView: QRScannerView, didSuccess code: String) {
         if let url = URL(string: code), (url.scheme == "http" || url.scheme == "https") {
             openWeb(url: url)
         } else {
@@ -53,7 +53,7 @@ extension ViewController: QRScannerViewDelegate {
         }
     }
 
-    func didChangeTorchActive(isOn: Bool) {
+    func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool) {
         flashButton.isSelected = isOn
     }
 }

--- a/README.md
+++ b/README.md
@@ -95,13 +95,17 @@ final class ViewController: UIViewController {
 }
 
 extension ViewController: QRScannerViewDelegate {
-    func failure(_ error: QRScannerError) {
-        print(error.localizedDescription)
-    }
+  func qrScannerView(_ qrScannerView: QRScannerView, didFailure error: QRScannerError) {
+      print(error.localizedDescription)
+  }
 
-    func success(_ code: String) {
-        print(code)
-    }
+  func qrScannerView(_ qrScannerView: QRScannerView, didSuccess code: String) {
+      print(code)
+  }
+
+  func qrScannerView(_ qrScannerView: QRScannerView, didChangeTorchActive isOn: Bool) {
+      // update torch button
+  }
 }
 ```
 ## Committers


### PR DESCRIPTION
From https://github.com/raywenderlich/swift-style-guide#delegates
>When creating custom delegate methods, an unnamed first parameter should be the delegate source. (UIKit contains numerous examples of this.)

I think this naming is better!