### PR TITLE
Stop changing torch acitve when QR scan is disabled

### DIFF
--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -80,7 +80,8 @@ public class QRScannerView: UIView {
         assert(Thread.isMainThread)
         
         guard let videoDevice = AVCaptureDevice.default(for: .video),
-            videoDevice.hasTorch, videoDevice.isTorchAvailable else {
+            videoDevice.hasTorch, videoDevice.isTorchAvailable,
+            (metadataOutputEnable || videoDataOutputEnable) else {
                 return
         }
         try? videoDevice.lockForConfiguration()


### PR DESCRIPTION
Torch active can be changed when user disable video authorization and QR scan is completed.
So I fix to change torch active value when only QR scanning