### PR TITLE
Add CI execution at pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
## Overview

At #8, CI runs on push.
But when pull request is opened CI does not run.

In this pull request I fix it.

- run CI when pull request is opened, synchronize, reopened
- run CI when master push

## Wiki

Pull Request event
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-event-pull_request

Push event
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

------

Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/
