### PR TITLE
Add blur effect

### DIFF
--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -31,17 +31,17 @@ public class QRScannerView: UIView {
         let focusImage: UIImage?
         let focusImagePadding: CGFloat?
         let animationDuration: Double?
-        let blurEffectEnable: Bool?
+        let isBlurEffectEnabled: Bool?
 
         public static var `default`: Input {
-            return .init(focusImage: nil, focusImagePadding: nil, animationDuration: nil, blurEffectEnable: nil)
+            return .init(focusImage: nil, focusImagePadding: nil, animationDuration: nil, isBlurEffectEnabled: nil)
         }
 
-        public init(focusImage: UIImage? = nil, focusImagePadding: CGFloat? = nil, animationDuration: Double? = nil, blurEffectEnable: Bool? = nil) {
+        public init(focusImage: UIImage? = nil, focusImagePadding: CGFloat? = nil, animationDuration: Double? = nil, isBlurEffectEnabled: Bool? = nil) {
             self.focusImage = focusImage
             self.focusImagePadding = focusImagePadding
             self.animationDuration = animationDuration
-            self.blurEffectEnable = blurEffectEnable
+            self.isBlurEffectEnabled = isBlurEffectEnabled
         }
     }
 
@@ -56,7 +56,7 @@ public class QRScannerView: UIView {
     public var animationDuration: Double = 0.5
 
     @IBInspectable
-    public var blurEffectEnable = false
+    public var isBlurEffectEnabled = false
 
     // MARK: - Public
 
@@ -71,8 +71,8 @@ public class QRScannerView: UIView {
         if let animationDuration = input.animationDuration {
             self.animationDuration = animationDuration
         }
-        if let blurEffectEnable = input.blurEffectEnable {
-            self.blurEffectEnable = blurEffectEnable
+        if let isBlurEffectEnabled = input.isBlurEffectEnabled {
+            self.isBlurEffectEnabled = isBlurEffectEnabled
         }
 
         configureSession()
@@ -102,7 +102,7 @@ public class QRScannerView: UIView {
 
     public func rescan() {
         guard isAuthorized() else { return }
-        if blurEffectEnable {
+        if isBlurEffectEnabled {
             blurEffectView.isHidden = true
         }
         focusImageView.removeFromSuperview()
@@ -245,7 +245,7 @@ public class QRScannerView: UIView {
     }
 
     private func setupBlurEffectView() {
-        guard blurEffectEnable else { return }
+        guard isBlurEffectEnabled else { return }
         blurEffectView.isHidden = true
         addSubview(blurEffectView)
     }
@@ -318,7 +318,7 @@ public class QRScannerView: UIView {
             }, completion: { [weak self] _ in
                 guard let strongSelf = self else { return }
                 strongSelf.qrCodeImageView.image = strongSelf.qrCodeImage
-                if strongSelf.blurEffectEnable {
+                if strongSelf.isBlurEffectEnabled {
                     strongSelf.blurEffectView.isHidden = false
                 }
                 strongSelf.success(qrCode)

--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -28,14 +28,20 @@ public class QRScannerView: UIView {
 
     // MARK: - Input
     public struct Input {
-        public var focusImage: UIImage?
-        public var focusImagePadding: CGFloat?
-        public var animationDuration: Double?
+        let focusImage: UIImage?
+        let focusImagePadding: CGFloat?
+        let animationDuration: Double?
+        let blurEffectEnable: Bool?
 
         public static var `default`: Input {
-            return .init(focusImage: nil,
-                         focusImagePadding: nil,
-                         animationDuration: nil)
+            return .init(focusImage: nil, focusImagePadding: nil, animationDuration: nil, blurEffectEnable: nil)
+        }
+
+        public init(focusImage: UIImage? = nil, focusImagePadding: CGFloat? = nil, animationDuration: Double? = nil, blurEffectEnable: Bool? = nil) {
+            self.focusImage = focusImage
+            self.focusImagePadding = focusImagePadding
+            self.animationDuration = animationDuration
+            self.blurEffectEnable = blurEffectEnable
         }
     }
 
@@ -48,6 +54,9 @@ public class QRScannerView: UIView {
 
     @IBInspectable
     public var animationDuration: Double = 0.5
+
+    @IBInspectable
+    public var blurEffectEnable = false
 
     // MARK: - Public
 
@@ -62,9 +71,13 @@ public class QRScannerView: UIView {
         if let animationDuration = input.animationDuration {
             self.animationDuration = animationDuration
         }
+        if let blurEffectEnable = input.blurEffectEnable {
+            self.blurEffectEnable = blurEffectEnable
+        }
 
         configureSession()
         addPreviewLayer()
+        setupBlurEffectView()
         setupImageViews()
     }
 
@@ -89,6 +102,9 @@ public class QRScannerView: UIView {
 
     public func rescan() {
         guard isAuthorized() else { return }
+        if blurEffectEnable {
+            blurEffectView.isHidden = true
+        }
         focusImageView.removeFromSuperview()
         qrCodeImageView.removeFromSuperview()
         setupImageViews()
@@ -140,6 +156,12 @@ public class QRScannerView: UIView {
     private var videoDataOutputEnable = false
     private var torchActiveObservation: NSKeyValueObservation?
     private var qrCodeImage: UIImage?
+    private lazy var blurEffectView: UIVisualEffectView = {
+        let blurEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        blurEffectView.frame = self.bounds
+        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        return blurEffectView
+    }()
 
     private enum AuthorizationStatus {
         case authorized, notDetermined, restrictedOrDenied
@@ -222,6 +244,12 @@ public class QRScannerView: UIView {
         }
     }
 
+    private func setupBlurEffectView() {
+        guard blurEffectEnable else { return }
+        blurEffectView.isHidden = true
+        addSubview(blurEffectView)
+    }
+
     private func setupImageViews() {
         let width = UIScreen.main.bounds.width * 0.618
         let x = UIScreen.main.bounds.width * 0.191
@@ -290,6 +318,9 @@ public class QRScannerView: UIView {
             }, completion: { [weak self] _ in
                 guard let strongSelf = self else { return }
                 strongSelf.qrCodeImageView.image = strongSelf.qrCodeImage
+                if strongSelf.blurEffectEnable {
+                    strongSelf.blurEffectView.isHidden = false
+                }
                 strongSelf.success(qrCode)
         })
     }

--- a/QRScannerSample/QRScannerSample/Base.lproj/Main.storyboard
+++ b/QRScannerSample/QRScannerSample/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -45,7 +45,7 @@
                     </view>
                     <connections>
                         <outlet property="flashButton" destination="79y-mq-bOP" id="jxg-iE-HM6"/>
-                        <outlet property="qrScannerView" destination="Lq8-gV-FhD" id="SFM-Eh-qaT"/>
+                        <outlet property="qrScannerView" destination="Lq8-gV-FhD" id="mRw-2F-wc5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/QRScannerSample/QRScannerSample/ViewController.swift
+++ b/QRScannerSample/QRScannerSample/ViewController.swift
@@ -13,7 +13,7 @@ final class ViewController: UIViewController {
     // MARK: - Outlets
     @IBOutlet var qrScannerView: QRScannerView! {
         didSet {
-            qrScannerView.configure(delegate: self, input: .init(blurEffectEnable: true))
+            qrScannerView.configure(delegate: self, input: .init(isBlurEffectEnabled: true))
         }
     }
     @IBOutlet var flashButton: FlashButton!

--- a/QRScannerSample/QRScannerSample/ViewController.swift
+++ b/QRScannerSample/QRScannerSample/ViewController.swift
@@ -13,7 +13,7 @@ final class ViewController: UIViewController {
     // MARK: - Outlets
     @IBOutlet var qrScannerView: QRScannerView! {
         didSet {
-            qrScannerView.configure(delegate: self)
+            qrScannerView.configure(delegate: self, input: .init(blurEffectEnable: true))
         }
     }
     @IBOutlet var flashButton: FlashButton!
@@ -21,6 +21,7 @@ final class ViewController: UIViewController {
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ extension ViewController: QRScannerViewDelegate {
 }
 ```
 
+### Add Blur Effect
+
+#### Source Code Way
+
+```
+     qrScannerView.configure(delegate: self, input: .init(blurEffectEnable: true))
+```
+
+#### Interface Builder Way
+
+```
+blurEffectEnable
+```
+
 ## Committers
 
 * Hitsu ([@hitsubunnu](https://github.com/hitsubunnu))

--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ extension ViewController: QRScannerViewDelegate {
 #### Source Code Way
 
 ```
-     qrScannerView.configure(delegate: self, input: .init(blurEffectEnable: true))
+     qrScannerView.configure(delegate: self, input: .init(isBlurEffectEnabled: true))
 ```
 
 #### Interface Builder Way
 
 ```
-blurEffectEnable
+isBlurEffectEnabled
 ```
 
 ## Committers


### PR DESCRIPTION
## Issues

resolves #12 

## Overview

1. Add blur effect
2. Add public init() for QRScannner.Input
For now if use QRScannner.Input(...) in Sample, it will cause the warning.
Warning: `'QRScannerView.Input' initializer is inaccessible due to 'internal' protection level`
```
public struct Input {
        public var focusImage: UIImage?
        public var focusImagePadding: CGFloat?
        public var animationDuration: Double?
        public var blurEffectEnable: Bool?

        public static var `default`: Input {
            return .init(focusImage: nil, focusImagePadding: nil, animationDuration: nil, blurEffectEnable: nil)
        }
}
```

3. Improve source code

## Note
![blurEffect](https://user-images.githubusercontent.com/66359/71166891-f9d2c500-2296-11ea-804f-e3e5de86fc59.gif)
