### PR TITLE
focusImageView: Use the frame of the QRScannerView instead of the mai…

### DIFF
--- a/QRScanner/QRScannerView.swift
+++ b/QRScanner/QRScannerView.swift
@@ -246,9 +246,9 @@ public class QRScannerView: UIView {
     }
 
     private func setupImageViews() {
-        let width = UIScreen.main.bounds.width * 0.618
-        let x = UIScreen.main.bounds.width * 0.191
-        let y = UIScreen.main.bounds.height * 0.191
+        let width = self.bounds.width * 0.618
+        let x = self.bounds.width * 0.191
+        let y = self.bounds.height * 0.191
         focusImageView = UIImageView(frame: CGRect(x: x, y: y, width: width, height: width))
         focusImageView.image = focusImage ?? UIImage(named: "scan_qr_focus", in: Bundle(for: QRScannerView.self), compatibleWith: nil)
         addSubview(focusImageView)


### PR DESCRIPTION
…nscreen bounds

When not using the QRScannerView in fullscreen, the focus view is not aligned correct.